### PR TITLE
Unngå blokkering av node ved venting på brukerinput

### DIFF
--- a/vars/naisFrontendPipelineMedDeployTilSBS.groovy
+++ b/vars/naisFrontendPipelineMedDeployTilSBS.groovy
@@ -6,9 +6,10 @@ def call() {
     def tagName=''
     def exitCode
     pipeline {
-        agent { label 'master' }
+        agent none
         stages {
             stage('Checkout Tags') { // checkout only tags.
+                agent { label 'master' }
                 steps {
                     script {
                         dockerRegistryIapp = "repo.adeo.no:5443"
@@ -20,6 +21,7 @@ def call() {
                 }
             }
             stage('Build and Push'){
+                agent { label 'master' }
                 steps {
                     sh 'PATH=$PATH:/usr/local/lib/node/nodejs/bin:/opt/yarn-v1.12.3/bin; yarn install --ignore-scripts'
                     sh 'PATH=$PATH:/usr/local/lib/node/nodejs/bin:/opt/yarn-v1.12.3/bin; yarn build'
@@ -29,6 +31,7 @@ def call() {
                 }
             }
             stage('Tag master') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -38,6 +41,7 @@ def call() {
                 }
             }
             stage('Deploy master til preprod') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -54,17 +58,23 @@ def call() {
                     }
                 }
             }
-            stage('Deploy master til prod?') {
+            stage('Godkjenn deploy av master til prod') {
+                agent none
                 when {
                     beforeInput true
                     branch 'master'
                 }
+                steps {
+                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                }
+            }
+            stage('Deploy master til prod') {
+                agent { label 'master' }
+                when {
+                    branch 'master'
+                }
                 options {
                     timeout(time: 3, unit: 'DAYS')
-                }
-                input {
-                    message "Vil du deploye master til prod?"
-                    ok "Ja, jeg vil deploye :)"
                 }
                 steps {
                     script {
@@ -79,7 +89,20 @@ def call() {
                     }
                 }
             }
-            stage('Deploy branch til preprod?') {
+            stage('Godkjenn deploy av branch til preprod') {
+                agent none
+                when {
+                    beforeInput true
+                    not {
+                        branch 'master'
+                    }
+                }
+                steps {
+                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                }
+            }
+            stage('Deploy branch til preprod') {
+                agent { label 'master' }
                 when {
                     not {
                         branch 'master'
@@ -87,10 +110,6 @@ def call() {
                 }
                 options {
                     timeout(time: 30, unit: 'MINUTES')
-                }
-                input {
-                    message "Vil du deploye til preprod?"
-                    ok "Ja, jeg vil deploye :)"
                 }
                 steps {
                     script {

--- a/vars/naisFrontendPipelineMedDeployTilSBS.groovy
+++ b/vars/naisFrontendPipelineMedDeployTilSBS.groovy
@@ -65,16 +65,15 @@ def call() {
                     branch 'master'
                 }
                 steps {
-                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 3, unit: 'DAYS') {
+                        input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy master til prod') {
                 agent { label 'master' }
                 when {
                     branch 'master'
-                }
-                options {
-                    timeout(time: 3, unit: 'DAYS')
                 }
                 steps {
                     script {
@@ -98,7 +97,9 @@ def call() {
                     }
                 }
                 steps {
-                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 30, unit: 'MINUTES') {
+                        input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy branch til preprod') {
@@ -107,9 +108,6 @@ def call() {
                     not {
                         branch 'master'
                     }
-                }
-                options {
-                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                     script {

--- a/vars/naisPipelineMedDeployTilFSS.groovy
+++ b/vars/naisPipelineMedDeployTilFSS.groovy
@@ -106,16 +106,15 @@ def call() {
                     branch 'master'
                 }
                 steps {
-                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 3, unit: 'DAYS') {
+                        input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy master til prod?') {
                 agent { label 'master' }
                 when {
                     branch 'master'
-                }
-                options {
-                    timeout(time: 3, unit: 'DAYS')
                 }
                 steps {
                     script {
@@ -139,7 +138,9 @@ def call() {
                     }
                 }
                 steps {
-                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 30, unit: 'MINUTES') {
+                        input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy branch til preprod?') {
@@ -148,9 +149,6 @@ def call() {
                     not {
                         branch 'master'
                     }
-                }
-                options {
-                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                     script {

--- a/vars/naisPipelineMedDeployTilFSS.groovy
+++ b/vars/naisPipelineMedDeployTilFSS.groovy
@@ -10,9 +10,10 @@ def call() {
     def exitCode
 
     pipeline {
-        agent { label 'master' }
+        agent none
         stages {
             stage('Checkout scm') {
+                agent { label 'master' }
                 steps {
                     script {
                         Date date = new Date()
@@ -37,6 +38,7 @@ def call() {
             }
 
             stage('Set version') {
+                agent { label 'master' }
                 steps {
                     sh "mvn --version"
                     sh "echo $version > VERSION"
@@ -44,6 +46,7 @@ def call() {
             }
 
             stage('Build') {
+                agent { label 'master' }
                 steps {
                     script {
                         withMaven (mavenSettingsConfig: 'navMavenSettings') {
@@ -69,6 +72,7 @@ def call() {
             }
 
             stage('Tag master') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -78,6 +82,7 @@ def call() {
                 }
             }
             stage('Deploy master til preprod') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -94,17 +99,23 @@ def call() {
                     }
                 }
             }
-            stage('Deploy master til prod?') {
+            stage('Godkjenn deploy av master til prod') {
+                agent none
                 when {
                     beforeInput true
                     branch 'master'
                 }
-                options {
-                    timeout(time: 3, unit: 'DAYS') 
+                steps {
+                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
                 }
-                input {
-                    message "Vil du deploye master til prod?"
-                    ok "Ja, jeg vil deploye :)"
+            }
+            stage('Deploy master til prod?') {
+                agent { label 'master' }
+                when {
+                    branch 'master'
+                }
+                options {
+                    timeout(time: 3, unit: 'DAYS')
                 }
                 steps {
                     script {
@@ -119,18 +130,27 @@ def call() {
                     }
                 }
             }
+            stage('Godkjenn deploy av branch til preprod') {
+                agent none
+                when {
+                    beforeInput true
+                    not {
+                        branch 'master'
+                    }
+                }
+                steps {
+                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                }
+            }
             stage('Deploy branch til preprod?') {
+                agent { label 'master' }
                 when {
                     not {
                         branch 'master'
                     }
                 }
                 options {
-                    timeout(time: 30, unit: 'MINUTES') 
-                }
-                input {
-                    message "Vil du deploye til preprod?"
-                    ok "Ja, jeg vil deploye :)"
+                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                     script {

--- a/vars/naisPipelineMedDeployTilSBS.groovy
+++ b/vars/naisPipelineMedDeployTilSBS.groovy
@@ -106,16 +106,15 @@ def call() {
                     branch 'master'
                 }
                 steps {
-                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 3, unit: 'DAYS') {
+                        input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy master til prod') {
                 agent { label 'master' }
                 when {
                     branch 'master'
-                }
-                options {
-                    timeout(time: 3, unit: 'DAYS')
                 }
                 steps {
                     script {
@@ -139,7 +138,9 @@ def call() {
                     }
                 }
                 steps {
-                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    timeout(time: 30, unit: 'MINUTES') {
+                        input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                    }
                 }
             }
             stage('Deploy branch til preprod') {
@@ -148,9 +149,6 @@ def call() {
                     not {
                         branch 'master'
                     }
-                }
-                options {
-                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                     script {

--- a/vars/naisPipelineMedDeployTilSBS.groovy
+++ b/vars/naisPipelineMedDeployTilSBS.groovy
@@ -10,9 +10,10 @@ def call() {
     def exitCode
 
     pipeline {
-        agent { label 'master' }
+        agent none
         stages {
             stage('Checkout scm') {
+                agent { label 'master' }
                 steps {
                     script {
                         Date date = new Date()
@@ -37,6 +38,7 @@ def call() {
             }
 
             stage('Set version') {
+                agent { label 'master' }
                 steps {
                     sh "mvn --version"
                     sh "echo $version > VERSION"
@@ -44,6 +46,7 @@ def call() {
             }
 
             stage('Build') {
+                agent { label 'master' }
                 steps {
                     script {
                         withMaven (mavenSettingsConfig: 'navMavenSettings') {
@@ -69,6 +72,7 @@ def call() {
             }
 
             stage('Tag master') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -78,6 +82,7 @@ def call() {
                 }
             }
             stage('Deploy master til preprod') {
+                agent { label 'master' }
                 when {
                     branch 'master'
                 }
@@ -94,17 +99,23 @@ def call() {
                     }
                 }
             }
-            stage('Deploy master til prod?') {
+            stage('Godkjenn deploy av master til prod') {
+                agent none
                 when {
                     beforeInput true
                     branch 'master'
                 }
+                steps {
+                    input message: 'Vil du deploye master til prod?', ok: 'Ja, jeg vil deploye :)'
+                }
+            }
+            stage('Deploy master til prod') {
+                agent { label 'master' }
+                when {
+                    branch 'master'
+                }
                 options {
                     timeout(time: 3, unit: 'DAYS')
-                }
-                input {
-                    message "Vil du deploye master til prod?"
-                    ok "Ja, jeg vil deploye :)"
                 }
                 steps {
                     script {
@@ -119,7 +130,20 @@ def call() {
                     }
                 }
             }
-            stage('Deploy branch til preprod?') {
+            stage('Godkjenn deploy av branch til preprod') {
+                agent none
+                when {
+                    beforeInput true
+                    not {
+                        branch 'master'
+                    }
+                }
+                steps {
+                    input message: 'Vil du deploye branch til preprod?', ok: 'Ja, jeg vil deploye :)'
+                }
+            }
+            stage('Deploy branch til preprod') {
+                agent { label 'master' }
                 when {
                     not {
                         branch 'master'
@@ -127,10 +151,6 @@ def call() {
                 }
                 options {
                     timeout(time: 30, unit: 'MINUTES')
-                }
-                input {
-                    message "Vil du deploye til preprod?"
-                    ok "Ja, jeg vil deploye :)"
                 }
                 steps {
                     script {


### PR DESCRIPTION
- `agent none` på toppnivå og agent settes i hvert stage
- For å sette `agent none` på kun kun input, flyttes input ut i separate stages. Unngår dermed å okkupere node ved venting på brukerinput.

Berørte pipelines er testa med branch _blocked-jenkins_ i appene soknad-kontantstotte-api (SBS), soknad-kontantstotte-proxy (FSS) og soknad-kontantstotte(frontent SBS). 